### PR TITLE
Fix for Issue #27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "blue.endless:jankson:1.2.3"
     include "blue.endless:jankson:1.2.3"
 
-    modCompileOnly "maven.modrinth:fishing-real:1.9.1-backport"
+    modCompileOnly "maven.modrinth:fishing-real:1.9.1"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx1G
 minecraft_version=1.21
 loader_version=0.16.9
 # Mod Properties
-mod_version=2.0.2+1.21
+mod_version=2.0.3+1.21
 maven_group=dev.doublekekse
 archives_base_name=Boids
 #Fabric api

--- a/src/main/java/dev/doublekekse/boids/mixin/compat/RealFishingMixin.java
+++ b/src/main/java/dev/doublekekse/boids/mixin/compat/RealFishingMixin.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(FishingReal.class)
 public class RealFishingMixin {
-    @Inject(method = "convertItemStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Mob;finalizeSpawn(Lnet/minecraft/world/level/ServerLevelAccessor;Lnet/minecraft/world/DifficultyInstance;Lnet/minecraft/world/entity/MobSpawnType;Lnet/minecraft/world/entity/SpawnGroupData;Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/world/entity/SpawnGroupData;"))
+    @Inject(method = "convertItemStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Mob;finalizeSpawn(Lnet/minecraft/world/level/ServerLevelAccessor;Lnet/minecraft/world/DifficultyInstance;Lnet/minecraft/world/entity/MobSpawnType;Lnet/minecraft/world/entity/SpawnGroupData;)Lnet/minecraft/world/entity/SpawnGroupData;"))
     private static void enable(ItemStack itemstack, Player player, Vec3 position, CallbackInfoReturnable<Entity> cir, @Local Mob mob) {
         ((MobDuck) mob).boids$disable();
     }


### PR DESCRIPTION
This PR fixes a critical mixin injection failure in the RealFishing compatibility module. The compatibility mixin targeted an outdated method signature for Mob#finalizeSpawn, causing the Boids mod to crash during game initialization whenever RealFishing was present.

Updating the @At(INVOKE) target descriptor and updating the fishing-real's dependency resolves the issue and restores full compatibility.


Changes:
- Updated Mod version from "2.0.2+1.21" to "2.0.3+1.21"
- Updated the fishing-real dependency from "maven.modrinth:fishing-real:1.9.1-backport" (this is for Minecraft 1.20.1) to "maven.modrinth:fishing-real:1.9.1" (this for Minecraft 1.21.1)
-  Updated method signature for Mob#finalizeSpan. This method takes 5 parameters in Minecraft versions 1.20.X, and now has been updated to just 4 parameters to be compatible with Minecraft version 1.21.X



Solves issue #27 
